### PR TITLE
Update class-option-multicheck.php

### DIFF
--- a/class-option-multicheck.php
+++ b/class-option-multicheck.php
@@ -16,7 +16,7 @@ class TitanFrameworkOptionMulticheck extends TitanFrameworkOption {
 
 		echo "<fieldset>";
 
-		$savedValue = $this->getValue();
+		$savedValue = $this->cleanValueForGetting( $this->getValue() );
 		if ( empty( $savedValue ) ) {
 			$savedValue = array();
 		}


### PR DESCRIPTION
I'm using multicheck-posts option in a metabox, and I received this error:

```
Warning: in_array() expects parameter 2 to be array, string given in 
/wp-content/plugins/titan-framework/class-option-multicheck.php on line 30
```

I printed out $savedValue and found out it's a serialized string. So I unserialized it using cleanValueForGetting method and it's working now.
Did you test multicheck options before?
Even in the demo theme ( http://demo.titanframework.net/wp-admin/post.php?post=2&action=edit ) you can't check any of the checkboxes (when you save the page they become unchecked again). And it's not displaying the error probably because debug mode is off.

Note: I used unserialize() function first instead of cleanValueForGetting method, but it gave me another error somewhere else where I was using 'multicheck' option and it didn't need to be unserialized because it was already an array.
