### PR TITLE
Adding .form-table onto table selector

### DIFF
--- a/js/admin-styling.js
+++ b/js/admin-styling.js
@@ -3,7 +3,7 @@ jQuery(document).ready(function($) {
 
 	// Removes the last blank table in admin pages. This is because a blank table is left if the last
 	// option is a save option
-	$('.titan-framework-panel-wrap table').filter(function() {
+	$('.titan-framework-panel-wrap table.form-table').filter(function() {
 		return $(this).find('tbody tr').length == 0;
 	}).remove();
 });


### PR DESCRIPTION
Adding the form-table class when selecting the tr to remove to not potentially interfere with custom types that contain tables with blank tbody's
