### PR TITLE
Add ability to set metabox priority

### DIFF
--- a/class-meta-box.php
+++ b/class-meta-box.php
@@ -13,6 +13,7 @@ class TitanFrameworkMetaBox {
 		// 'position' => 100.01 // Menu position for top level menus only
 		'post_type' => 'page', // Post type, can be an array of post types
 		'context' => 'normal', // normal, advanced, or side
+		'priority' => 'high', // 'high', 'core', 'default' or 'low'
 		'hide_custom_fields' => true, // If true, the custom fields box will not be shown
 	);
 
@@ -65,7 +66,7 @@ class TitanFrameworkMetaBox {
 				array( $this, 'display' ),
 				$postType,
 				$this->settings['context'],
-				'high' );
+				$this->settings['priority'] );
 		}
 	}
 


### PR DESCRIPTION
Adds the ability to set the priority on metaboxes. 

Example:

```

add_action( 'admin_init', function() {

    $titan = TitanFramework::getInstance( 'titan-test' );

    $box = $titan->createMetaBox( array(
        'name' => 'Meta Box 1',
        'post_type' => 'post',
        'priority' => 'low',
    ) );

    $box->createOption( array(
        'name' => 'My Option',
        'id' => 'my_option_1',
    ) );


    $box = $titan->createMetaBox( array(
        'name' => 'Meta Box 2',
        'post_type' => 'post',
    ) );

    $box->createOption( array(
        'name' => 'My Option',
        'id' => 'my_option_2',
    ) );

});
```
