### PR TITLE
Ajax button improvements

### DIFF
--- a/lib/class-option-ajax-button.php
+++ b/lib/class-option-ajax-button.php
@@ -162,7 +162,7 @@ class TitanFrameworkOptionAjaxButton extends TitanFrameworkOption {
 		<script>
 		jQuery(document).ready(function($) {
 			"use strict";
-			
+
 			$('.form-table, .customize-control').on( 'click', '.tf-ajax-button .button', function( e ) {
 
 				// Only perform one ajax at a time
@@ -174,7 +174,7 @@ class TitanFrameworkOptionAjaxButton extends TitanFrameworkOption {
 					return false;
 				}
 				this.doingAjax = true;
-				
+
 				// Form the data to send, we send the nonce and the post ID if possible
 				var data = { nonce: $(this).attr('data-nonce') };
 				<?php
@@ -183,61 +183,73 @@ class TitanFrameworkOptionAjaxButton extends TitanFrameworkOption {
 					?>data['id'] = <?php echo esc_attr( $post->ID ) ?>;<?php
 				}
 				?>
-				
+
 				// Perform the ajax call
 				wp.ajax.send( $(this).attr('data-action'), {
-					
+
 					// Success callback
-					success: function( successMessage ) {
-						
-						this.labelTimer = setTimeout(function() {
-							$(this).text( $(this).attr('data-label') );
-							this.labelTimer = undefined;
-						}.bind(this), 3000 );
-						
-						$(this).text( successMessage || $(this).attr('data-success-label') );
-						
-						// Call the error callback
-						if ( $(this).attr('data-success-callback') != '' ) {
-							if ( typeof window[ $(this).attr('data-success-callback') ] != 'undefined' ) {
-								window[ $(this).attr('data-success-callback') ]();
-							}
-						}
-						this.doingAjax = false;
-						
-					}.bind(this),
-					
-					// Error callback
-					error: function( errorMessage ) {
+					success: function( data ) {
+
 						this.labelTimer = setTimeout(function() {
 							$(this).text( $(this).attr('data-label') );
 							this.labelTimer = undefined;
 						}.bind(this), 3000 );
 
-						$(this).text( errorMessage || $(this).attr('data-error-label') );
-						
+						var successMessage = $(this).attr('data-success-label');
+						if (typeof data === 'string' || data instanceof String) {
+							successMessage = data;
+						} else if (typeof data.message !== 'undefined') {
+							successMessage = data.message;
+						}
+						$(this).text( successMessage );
+
 						// Call the error callback
-						if ( $(this).attr('data-error-callback') != '' ) {
-							if ( typeof window[ $(this).attr('data-error-callback') ] != 'undefined' ) {
-								window[ $(this).attr('data-error-callback') ]();
+						if ( $(this).attr('data-success-callback') != '' ) {
+							if ( typeof window[ $(this).attr('data-success-callback') ] != 'undefined' ) {
+								window[ $(this).attr('data-success-callback') ]( data );
 							}
 						}
 						this.doingAjax = false;
-						
+
 					}.bind(this),
-				
+
+					// Error callback
+					error: function( data ) {
+						this.labelTimer = setTimeout(function() {
+							$(this).text( $(this).attr('data-label') );
+							this.labelTimer = undefined;
+						}.bind(this), 3000 );
+
+						var errorMessage = $(this).attr('data-error-label');
+						if (typeof data === 'string' || data instanceof String) {
+							errorMessage = data;
+						} else if (typeof data.message !== 'undefined') {
+							errorMessage = data.message;
+						}
+						$(this).text( errorMessage );
+
+						// Call the error callback
+						if ( $(this).attr('data-error-callback') != '' ) {
+							if ( typeof window[ $(this).attr('data-error-callback') ] != 'undefined' ) {
+								window[ $(this).attr('data-error-callback') ]( data );
+							}
+						}
+						this.doingAjax = false;
+
+					}.bind(this),
+
 					// Pass the data
 					data: data
-					
+
 				});
-				
+
 				// Clear the label timer
 				if ( typeof this.labelTimer != 'undefined' ) {
 					clearTimeout( this.labelTimer );
 					this.labelTimer = undefined;
 				}
 				$(this).text( $(this).attr('data-wait-label') );
-				
+
 				return false;
 			} );
 		});

--- a/lib/class-option-ajax-button.php
+++ b/lib/class-option-ajax-button.php
@@ -15,6 +15,7 @@ class TitanFrameworkOptionAjaxButton extends TitanFrameworkOption {
 		'error_label' => '',
 		'success_callback' => '',
 		'error_callback' => '',
+		'data_filter_callback' => '',
 	);
 
 
@@ -85,6 +86,9 @@ class TitanFrameworkOptionAjaxButton extends TitanFrameworkOption {
 		while ( count( $this->settings['error_callback'] ) < count( $this->settings['action'] ) ) {
 			$this->settings['error_callback'][] = __( 'Something went wrong', TF_I18NDOMAIN );
 		}
+		while ( count( $this->settings['data_filter_callback'] ) < count( $this->settings['action'] ) ) {
+			$this->settings['data_filter_callback'][] = '';
+		}
 
 		foreach ( $this->settings['label'] as $i => $label ) {
 			if ( empty( $label ) ) {
@@ -129,7 +133,7 @@ class TitanFrameworkOptionAjaxButton extends TitanFrameworkOption {
 		$this->echoOptionHeader();
 
 		foreach ( $this->settings['action'] as $i => $action ) {
-			printf( '<button class="button %s" data-action="%s" data-label="%s" data-wait-label="%s" data-error-label="%s" data-success-label="%s" data-nonce="%s" data-success-callback="%s" data-error-callback="%s">%s</button>',
+			printf( '<button class="button %s" data-action="%s" data-label="%s" data-wait-label="%s" data-error-label="%s" data-success-label="%s" data-nonce="%s" data-success-callback="%s" data-error-callback="%s" data-data-filter-callback="%s">%s</button>',
 				$this->settings['class'][ $i ],
 				esc_attr( $action ),
 				esc_attr( $this->settings['label'][ $i ] ),
@@ -139,6 +143,7 @@ class TitanFrameworkOptionAjaxButton extends TitanFrameworkOption {
 				esc_attr( wp_create_nonce( 'tf-ajax-button' ) ),
 				esc_attr( $this->settings['success_callback'][ $i ] ),
 				esc_attr( $this->settings['error_callback'][ $i ] ),
+				esc_attr( $this->settings['data_filter_callback'][ $i ] ),
 				esc_attr( $this->settings['label'][ $i ] )
 			);
 		}
@@ -184,6 +189,9 @@ class TitanFrameworkOptionAjaxButton extends TitanFrameworkOption {
 				}
 				?>
 
+				if ( $(this).attr('data-data-filter-callback') !== '' && typeof window[ $(this).attr('data-data-filter-callback') ] !== 'undefined' ) {
+					data = window[ $(this).attr('data-data-filter-callback') ]( data );
+				}
 				// Perform the ajax call
 				wp.ajax.send( $(this).attr('data-action'), {
 


### PR DESCRIPTION
These changes allow you to handle more complex cases. You can send additional post data in the ajax request and get access for ajax response in success and error callbacks. This also fix cases, when you send the object/array in `wp_send_json_success()` or `wp_send_json_error()`

```php
$box->createOption(array(
	'name' => 'Perform Action',
	'type' => 'ajax-button',
	'action' => 'my_action',
	'success_callback' => 'myActionRefreshed',
	'data_filter_callback' => 'myActionFilterData',
));

// register callback functions for ajax button
add_action('admin_footer', function() {
	?>
	<script>
		function myActionRefreshed(data) {
			console.log(data.myvalue);
		}
		function myActionFilterData(data) {
			data.test = 'test value';
			return data;
		}
	</script>
	<?php
});

// register ajax action for ajax button
add_action('wp_ajax_my_action', function () {
	wp_send_json_success(array(
		'myvalue' => 'test',
		'message' => 'Great success!',
	));
});
```