### PR TITLE
add a field with autocompletion

### DIFF
--- a/js/option-text-autocomplete.js
+++ b/js/option-text-autocomplete.js
@@ -1,40 +1,49 @@
-console.log('option-text-autocomplete');
+jQuery(document).ready(function($) {
+	"use strict";
 
-jQuery(function() {
-    var cache = {};
-    jQuery( ".autocomplete" ).autocomplete({
-      minLength: 2,
-      source: function( request, response ) {
-        var term = request.term;
-        if ( term in cache ) {
-          response( cache[ term ] );
-          return;
-        }
+	var cache = {};
+	$( ".autocomplete" ).autocomplete({
+		minLength: 2,
+		source: function( request, response ) {
+			var term = request.term;
+			if ( term in cache ) {
+				response( cache[ term ] );
+				return;
+			}
 
-        var pp = jQuery.extend(request, autocomplete_params, {
-        	post_type: jQuery(this.element.context).attr('data-post-type'),
-        });
+			$.getJSON( ajaxurl,
+				$.extend(request, autocomplete_params, {
+					post_type: $(this.element.context).attr('data-post-type'),
+				}),
+				function( data, status, xhr ) {
+					console.log(data);
+					data = data.map(function(post, i) {
+						return {
+							value: post.ID,
+							label: post.post_title
+						};
+					});
+					cache[ term ] = data;
+					response( data );
+				}
+			);
+		},
+		focus: function( event, ui ) {
+			$(this).val(ui.item.label);
+			return false;
+		},
+		select: function( event, ui ) {
+			$(this).val(ui.item.label);
+			return false;
+		},
+		change: function( event, ui ) {
+			const $target = $('#' + $(this).attr('data-target-id'))
+			if (ui.item === null) {
+				$target.val('');
+			} else {
+				$target.val(ui.item.value);
+			}
+		},
+	});
 
-        jQuery.getJSON( ajaxurl, pp, function( data, status, xhr ) {
-        	data = data.map(function(post, i) {
-        		return {
-        			value: post.ID,
-        			label: post.post_title
-        		};
-        	});
-          cache[ term ] = data;
-          response( data );
-        });
-      },
-      focus: function( event, ui ) {
-        jQuery(this).val(ui.item.label);
-        return false;
-      },
-      select: function( event, ui ) {
-      	jQuery(this).val(ui.item.label);
-      	jQuery('#' + jQuery(this).attr('data-target-id')).val(ui.item.value);
-
-      	return false;
-      }
-    });
-  });
+});

--- a/js/option-text-autocomplete.js
+++ b/js/option-text-autocomplete.js
@@ -1,0 +1,40 @@
+console.log('option-text-autocomplete');
+
+jQuery(function() {
+    var cache = {};
+    jQuery( ".autocomplete" ).autocomplete({
+      minLength: 2,
+      source: function( request, response ) {
+        var term = request.term;
+        if ( term in cache ) {
+          response( cache[ term ] );
+          return;
+        }
+
+        var pp = jQuery.extend(request, autocomplete_params, {
+        	post_type: jQuery(this.element.context).attr('data-post-type'),
+        });
+
+        jQuery.getJSON( ajaxurl, pp, function( data, status, xhr ) {
+        	data = data.map(function(post, i) {
+        		return {
+        			value: post.ID,
+        			label: post.post_title
+        		};
+        	});
+          cache[ term ] = data;
+          response( data );
+        });
+      },
+      focus: function( event, ui ) {
+        jQuery(this).val(ui.item.label);
+        return false;
+      },
+      select: function( event, ui ) {
+      	jQuery(this).val(ui.item.label);
+      	jQuery('#' + jQuery(this).attr('data-target-id')).val(ui.item.value);
+
+      	return false;
+      }
+    });
+  });

--- a/lib/class-option-text-autocomplete.php
+++ b/lib/class-option-text-autocomplete.php
@@ -1,0 +1,93 @@
+<?php
+/**
+ * Text Option
+ *
+ * @package Titan Framework
+ */
+if ( ! defined( 'ABSPATH' ) ) { exit; // Exit if accessed directly.
+}
+/**
+ * Text Option
+ *
+ * Creates a text option
+ *
+ * <strong>Creating a text option:</strong>
+ * <pre>$panel->createOption( array(
+ *     'name' => 'My Text Option',
+ *     'id' => 'my_text_option',
+ *     'type' => 'text',
+ *     'desc' => 'This is our option',
+ * ) );</pre>
+ *
+ * @since 1.0
+ * @type text
+ * @availability Admin Pages|Meta Boxes|Customizer
+ */
+class TitanFrameworkOptionTextAutocomplete extends TitanFrameworkOptionText {
+
+	function __construct( $settings, $owner ) {
+		parent::__construct( $settings, $owner );
+		add_action('wp_ajax_option-text-autocomplete', array( $this, 'autocomplete_ajax_callback' ));
+	}
+
+	public function display() {
+
+
+		$this->register_autocomplete_script();
+		$this->echoOptionHeader();
+
+		$val = $this->getValue();
+		$title = '';
+
+		if (!empty($val)) {
+			$posts = get_posts(array(
+				'p' => $val,
+				'post_type' => $this->settings['post_type'])
+			);
+			if (!empty($posts)) {
+				$title = $posts[0]->post_title;
+			}
+		}
+		// echo '<pre>'.print_r($posts,1).'</pre>';
+
+		printf('<input name="%s" id="%s" type="hidden" value="%s" \>',
+			$this->getID(),
+			$this->getID(),
+			esc_attr( $val )
+		);
+
+		printf('<input class="%s-text autocomplete" name="%s-post_title" placeholder="%s" maxlength="%s" id="%s-post_title" type="text" value="%s" data-post-type="%s" data-target-id="%s" \>%s',
+			empty($this->settings['size']) ? 'regular' : $this->settings['size'],
+			$this->getID(),
+			$this->settings['placeholder'],
+			$this->settings['maxlength'],
+			$this->getID(),
+			esc_attr( $title ),
+			$this->settings['post_type'],
+			$this->getID(),
+			$this->settings['hidden'] ? '' : ' ' . $this->settings['unit']
+		);
+		$this->echoOptionFooter();
+	}
+
+	public function register_autocomplete_script() {
+		wp_enqueue_script('option-text-autocomplete',  TitanFramework::getURL( '../js/option-text-autocomplete.js', __FILE__ ), array('jquery', 'jquery-ui-autocomplete'));
+
+		wp_localize_script( 'option-text-autocomplete', 'autocomplete_params',
+			array(
+			   'action' => 'option-text-autocomplete',
+			   '_ajax_nonce' => wp_create_nonce('autocomplete_params-nonce'),
+			));
+	}
+
+	public function autocomplete_ajax_callback() {
+		// echo "string";
+		check_ajax_referer( 'autocomplete_params-nonce');
+
+		$query = new WP_Query( array(
+			's' => $_GET['term'],
+			'post_type' => $_GET['post_type']
+		));
+		wp_send_json($query->posts);
+	}
+}

--- a/lib/class-option-text.php
+++ b/lib/class-option-text.php
@@ -56,7 +56,7 @@ class TitanFrameworkOptionText extends TitanFrameworkOption {
 		 * @var boolean
 		 */
 		'is_password' => false,
-		
+
 		/**
 		 * (Optional) If true, the input field itself will be completely hidden. Takes precedence over password.
 		 *
@@ -103,7 +103,7 @@ class TitanFrameworkOptionText extends TitanFrameworkOption {
 		// If hidden, takes precedence over password field.
 		$thePass = $this->settings['is_password'] ? 'password' : 'text';
 		$theType = $this->settings['hidden'] ? 'hidden' : $thePass;
-		printf('<input class="%s-text" name="%s" placeholder="%s" maxlength="%s" id="%s" type="%s" value="%s"\>%s',
+		printf('<input class="%s-text" name="%s" placeholder="%s" maxlength="%s" id="%s" type="%s" value="%s" %s \>%s',
 			empty($this->settings['size']) ? 'regular' : $this->settings['size'],
 			$this->getID(),
 			$this->settings['placeholder'],
@@ -111,6 +111,7 @@ class TitanFrameworkOptionText extends TitanFrameworkOption {
 			$this->getID(),
 			$theType,
 			esc_attr( $this->getValue() ),
+			$this->settings['readonly'] ? 'readonly' : '',
 			$this->settings['hidden'] ? '' : ' ' . $this->settings['unit']
 		);
 		$this->echoOptionFooter();

--- a/lib/class-option-text.php
+++ b/lib/class-option-text.php
@@ -64,6 +64,13 @@ class TitanFrameworkOptionText extends TitanFrameworkOption {
 		 * @var boolean
 		 */
 		'hidden' => false,
+		/**
+		 * (Optional) If true, the input field itself will be completely hidden. Takes precedence over password.
+		 *
+		 * @since 1.9.4
+		 * @var boolean
+		 */
+		'readonly' => false,
 
 		/**
 		 * (Optional) Callback function to call for additional input sanitization, this function will be called right before the option is saved.

--- a/titan-framework.php
+++ b/titan-framework.php
@@ -68,6 +68,7 @@ require_once( TF_PATH . 'lib/class-option-select.php' );
 require_once( TF_PATH . 'lib/class-option-separator.php' );
 require_once( TF_PATH . 'lib/class-option-sortable.php' );
 require_once( TF_PATH . 'lib/class-option-text.php' );
+require_once( TF_PATH . 'lib/class-option-text-autocomplete.php' );
 require_once( TF_PATH . 'lib/class-option-textarea.php' );
 require_once( TF_PATH . 'lib/class-option-upload.php' );
 require_once( TF_PATH . 'lib/class-titan-css.php' );


### PR DESCRIPTION
I add a field with autocomplete. Accepts post_type option to search posts. Saves post ID. ID can directly itself or in a different field.

Added option readonly for text fields. It is useful if the field should be kept post ID obtained from another field (eg field with autocomplete).
![2016-04-27 20-29-32](https://cloud.githubusercontent.com/assets/1662812/14861652/ca8b5982-0cb6-11e6-9f51-d4a78c9b554f.png)
