### PR TITLE
Load Ace only on admin settings pages

### DIFF
--- a/lib/class-option-code.php
+++ b/lib/class-option-code.php
@@ -61,7 +61,7 @@ class TitanFrameworkOptionCode extends TitanFrameworkOption {
 	function __construct( $settings, $owner ) {
 		parent::__construct( $settings, $owner );
 
-		add_action( 'admin_enqueue_scripts', array( $this, 'loadAdminScripts' ) );
+		add_action('tf_admin_page_before', array( $this, 'loadAdminScripts' ) );
 		add_action( 'customize_controls_enqueue_scripts', array( $this, 'loadAdminScripts' ) );
 
 		// CSS generation for CSS code langs


### PR DESCRIPTION
This solves and issue with visual composer and possibly other plugins which also attempt to load Ace.
