### PR TITLE
Add filter for wp_enque_style $deps

### DIFF
--- a/lib/class-titan-css.php
+++ b/lib/class-titan-css.php
@@ -99,7 +99,11 @@ class TitanFrameworkCSS {
 			$generatedCss = $this->getCSSFilePath();
 
 			if ( file_exists( $generatedCss ) && empty( $css ) ) {
-				wp_enqueue_style( 'tf-compiled-options-' . $this->frameworkInstance->optionNamespace, $this->getCSSFileURL(), __FILE__ );
+				wp_enqueue_style(
+					'tf-compiled-options-' . $this->frameworkInstance->optionNamespace, 
+					$this->getCSSFileURL(), 
+					apply_filters( 'tf_css_deps_' . $this->frameworkInstance->optionNamespace, array() )
+				);
 			}
 		}
 	}


### PR DESCRIPTION
This allows to control the order in which the generated CSS is loaded.