### PR TITLE
Fix: unserialize() expects parameter 1 to be string, array given

### DIFF
--- a/lib/class-titan-framework.php
+++ b/lib/class-titan-framework.php
@@ -256,7 +256,7 @@ class TitanFramework {
 
 		// Put all the available options in our global variable for future checking.
 		if ( ! empty( $currentOptions ) && ! count( $this->adminOptions ) ) {
-			$this->adminOptions = unserialize( $currentOptions );
+			$this->adminOptions = maybe_unserialize( $currentOptions );
 		}
 
 		if ( empty( $this->adminOptions ) ) {


### PR DESCRIPTION
Hi there,

This is a small patch related to unserialize functions.

`
Warning: unserialize() expects parameter 1 to be string, array given in /home/testwp/assets/plugins/divi-machine/titan-framework/lib/class-titan-framework.php on line 259
`

Thanks.